### PR TITLE
refactor: Add query param in drm license request url

### DIFF
--- a/docs/mobile-sdk/android-native-sdk/getting-started.md
+++ b/docs/mobile-sdk/android-native-sdk/getting-started.md
@@ -92,7 +92,7 @@ override fun onCreate(savedInstanceState: Bundle?) {
             val parameters = TpInitParams.Builder()
                 .setVideoId(videoId)
                 .setAccessToken(accessToken)
-                .setOrgCode("your_subdomain")
+                .setOrgCode("organization_id")
                 .build()
             player.load(parameters)
         }

--- a/docs/server-api/drm.md
+++ b/docs/server-api/drm.md
@@ -6,10 +6,10 @@ sidebar_position: 5
 
 To play DRM protected videos, your player should request DRM licence from our URL.
 
-This API requires [authentication Header](../server-api/authentication.md)
+This API requires [access_token](../video-embedding/authentication.md) in query param for authentication.
 
 ```bash
-POST: https://app.tpstreams.com/api/v1/<organization_id>/assets/<asset_id>/drm_license/
+POST: https://app.tpstreams.com/api/v1/<organization_id>/assets/<asset_id>/drm_license/?access_token={{access_token}}/
 ```
 
 :::note


### PR DESCRIPTION
- Add `access_token` query param in drm license request url
- This commit also changes typo in mobile-sdk parameters