### PR TITLE
Add instructions to cancel transcoding job

### DIFF
--- a/docs/transcoding-service/transcoding-cancelation.md
+++ b/docs/transcoding-service/transcoding-cancelation.md
@@ -1,0 +1,16 @@
+---
+sidebar_position: 4
+---
+
+# Cancel Transcoding Job 
+
+To cancel a transcoding job, you need to send an HTTP DELETE request to the API Endpoint .
+
+**Endpoint**
+```bash
+https://app.tpstreams.com/api/v1/<organization_id>/transcoding_jobs/<job_id>/
+```
+
+:::important
+ You can only cancel transcoding jobs that are not in a completed status.
+:::


### PR DESCRIPTION
Added instructions to the documentation for canceling a transcoding job. The guide includes details on sending an HTTP DELETE request to the API Endpoint and provides an example API request.