### PR TITLE
refactor: Change enable_drm' field to 'enable_drm_for_recording' in live stream doc

### DIFF
--- a/docs/live-stream-api/create_live_stream_instantly.md
+++ b/docs/live-stream-api/create_live_stream_instantly.md
@@ -17,14 +17,14 @@ https://app.tpstreams.com/api/v1/<organization_id>/assets/live_streams/
 | Name             | Type         | Description |    Required  |
 | -----------      | -----------  | ----------- |   ---------- |
 | title            | string      |  Specify a text string or identifier which can be used for filtering or searching the live stream.| Yes |
-| enable_drm       | boolean      | A boolean value to enable or disable DRM for live stream recording.| No |
+| enable_drm_for_recording       | boolean      | A boolean value to enable or disable DRM for live stream recording.| No |
 
 **Sample request body**
 
 ```json 
 {
   "title": "Data science Live class",
-  "enable_drm": true
+  "enable_drm_for_recording": true
 }
 
 ```

--- a/docs/live-stream-api/list-live-stream-api.md
+++ b/docs/live-stream-api/list-live-stream-api.md
@@ -30,7 +30,7 @@ https://app.tpstreams.com/api/v1/<organization_id>/assets/live_streams/
                 "hls_url": "https://d3cydmgt9q030i.cloudfront.net/live/89b2cy/8DH94uXQgrA/video.m3u8",
                 "start": "2023-12-07 13:02:16",
                 "transcode_recorded_video": true,
-                "enable_drm": true,
+                "enable_drm_for_recording": true,
                 "chat_embed_url": null,
                 "resolutions": [
                     "240p",
@@ -54,7 +54,7 @@ https://app.tpstreams.com/api/v1/<organization_id>/assets/live_streams/
                 "hls_url": "https://d3cydmgt9q030i.cloudfront.net/live/89b2cy/9QgXR3pPj49/video.m3u8",
                 "start": "2023-12-07 12:34:42",
                 "transcode_recorded_video": true,
-                "enable_drm": true,
+                "enable_drm_for_recording": true,
                 "chat_embed_url": null,
                 "resolutions": [
                     "240p",

--- a/docs/live-stream-api/live-stream/schedule-a-live-stream.md
+++ b/docs/live-stream-api/live-stream/schedule-a-live-stream.md
@@ -19,7 +19,7 @@ https://app.tpstreams.com/api/v1/<organization_id>/assets/live_streams/
 | -----------      | -----------  | ----------- |   ---------- |
 | title            | string      |  Specify a text string or identifier which can be used for filtering or searching the live stream.| Yes |
 | start            | string      |  Specify the date and time (in the format: "YYYY-MM-DD HH:MM:SS") when the live stream should be scheduled.| Yes |
-| enable_drm       | boolean      | A boolean value to enable or disable DRM for live stream recording.| No |
+| enable_drm_for_recording       | boolean      | A boolean value to enable or disable DRM for live stream recording.| No |
 
 **Sample request body**
 
@@ -27,7 +27,7 @@ https://app.tpstreams.com/api/v1/<organization_id>/assets/live_streams/
 {
   "title": "Data science Live class",
   "start": "2024-10-05 15:30:00",
-  "enable_drm": false
+  "enable_drm_for_recording": false
 }
 
 ```
@@ -48,7 +48,7 @@ For valid requests the API server returns a JSON:
         "hls_url": "https://d28qihy7z761lk.cloudfront.net/live/gnarys/AuC9yX2EtBr/video.m3u8",
         "start": "2024-10-05 15:30:00",
         "transcode_recorded_video": true,
-        "enable_drm": false,
+        "enable_drm_for_recording": false,
         "chat_embed_url": null,
         "resolutions": [
             "240p",

--- a/docs/live-stream-api/live-stream/start-server.md
+++ b/docs/live-stream-api/live-stream/start-server.md
@@ -27,7 +27,7 @@ For valid requests the API server returns a JSON:
         "hls_url": "https://d3cydmgt9q030i.cloudfront.net/live/edee9b/8XGEEj6ptnB/video.m3u8",
         "start": "2024-10-05 15:30:00",
         "transcode_recorded_video": true,
-        "enable_drm": false,
+        "enable_drm_for_recording": false,
         "chat_embed_url": "https://app.tpstreams.com/live-chat/edee9b/8XGEEj6ptnB/",
         "resolutions": [
             "240p",

--- a/docs/live-stream-api/stop-a-live-stream-api.md
+++ b/docs/live-stream-api/stop-a-live-stream-api.md
@@ -38,7 +38,7 @@ If the value of the parameter "transcode_recorded_video" is set to true, you wil
         "resolutions": ["240p", "360p", "480p", "720p"],
         "video_codec": "h264",
         "audio_codec": "aac",
-        "enable_drm": true,
+        "enable_drm_for_recording": true,
         "tracks": [],
         "inputs": [
             {


### PR DESCRIPTION
Renamed the 'enable_drm' field to 'enable_drm_for_recording' 