### PR TITLE
docs: Remove Analytics data from Asset List API response

### DIFF
--- a/docs/server-api/assets.md
+++ b/docs/server-api/assets.md
@@ -147,12 +147,6 @@ https://app.tpstreams.com/api/v1/<organization_id>/assets/
             "live_stream": null,
             "parent": null,
             "parent_id": null,
-            "views_count": 464,
-            "average_watched_time": 473,
-            "total_watch_time": 189192,
-            "unique_viewers_count": 412,
-            "download_url": "https://d28qihy7z761lk.cloudfront.net/private/yXrprYum2TS.mp4?response-content-disposition=attachment%3B+filename%3DBig+Buck+Bunny+Video.mp4&Expires=1708718514&Signature=wzuk7MhZsjKE9MwG0yaM1cMMFurc3ZIhCmrR0~fx2vgSwVd1d0B68GG~KwE6upj8XJMn~5zrBcadlf8TWeFuRyoRbIw6vipEDbWYLdPQhLwZcHp7mwz7ERNpikvBZJUO7KB5Z~h6BSGvcDBnVVc9pNZ8W2Zz95Ix28dnNhr~J9fqEgHtd0KaOqmX~LVjbHq56u6NiYrm4SZm3hmnWsfuaShWVJzkEBGrgnx8EnYtYe4JkHEBSvnskJvQPuCz82gwlK4vxNSdJ~0g08xkcwkJQG1mLqi39gbumkalS-8jp-pAKoyHMpXsHO6m9FKpwHHjnHp2wwPlSOykUPk1dcrt8Q__&Key-Pair-Id=K2XWKDWM065EGO"
-
         },
         {
             "title": "Data science Live class",
@@ -178,11 +172,6 @@ https://app.tpstreams.com/api/v1/<organization_id>/assets/
             },
             "parent": null,
             "parent_id": null,
-            "views_count": 523,
-            "average_watched_time": 653,
-            "total_watch_time": 189192,
-            "unique_viewers_count": 412,
-            "download_url": "https://d28qihy7z761lk.cloudfront.net/private/yXrprYum2TS.mp4?response-content-disposition=attachment%3B+filename%3DBig+Buck+Bunny+Video.mp4&Expires=1708718514&Signature=wzuk7MhZsjKE9MwG0yaM1cMMFurc3ZIhCmrR0~fx2vgSwVd1d0B68GG~KwE6upj8XJMn~5zrBcadlf8TWeFuRyoRbIw6vipEDbWYLdPQhLwZcHp7mwz7ERNpikvBZJUO7KB5Z~h6BSGvcDBnVVc9pNZ8W2Zz95Ix28dnNhr~J9fqEgHtd0KaOqmX~LVjbHq56u6NiYrm4SZm3hmnWsfuaShWVJzkEBGrgnx8EnYtYe4JkHEBSvnskJvQPuCz82gwlK4vxNSdJ~0g08xkcwkJQG1mLqi39gbumkalS-8jp-pAKoyHMpXsHO6m9FKpwHHjnHp2wwPlSOykUPk1dcrt8Q__&Key-Pair-Id=K2XWKDWM065EGO"
         }
     ]
 }


### PR DESCRIPTION
- Previously, the Asset List API documentation included Analytics data in the response, which was misleading. This update removes references to Analytics data from the API response documentation to ensure accuracy.