### PR TITLE
docs: Add docs for trim scheduling in stop live stream API

### DIFF
--- a/docs/live-stream-api/stop-a-live-stream-api.md
+++ b/docs/live-stream-api/stop-a-live-stream-api.md
@@ -13,6 +13,55 @@ https://app.tpstreams.com/api/v1/<organization_id>/assets/<str:asset_id>/stop_li
 
 This will stop the specified live stream
 
+For valid requests the API server returns a JSON:
+
+```json
+{
+    "message": "Live stream stopped successfully",
+    "trim_scheduled": false
+}
+```
+
+## Schedule Trim After Live Stream
+
+You can optionally add trim parameters to the stop API request body to schedule a trim operation that will be executed after the live stream recording is completed and transcoded. This allows you to trim the recorded video directly when stopping the live stream.
+
+**Fields for Trim Scheduling**
+
+| Name             | Type         | Description |    Required  |
+| -----------      | -----------  | ----------- |   ---------- |
+| start_time       | integer      | Start time in seconds from the beginning of the recording | Yes (for trim) |
+| end_time         | integer      | End time in seconds from the beginning of the recording | Yes (for trim) |
+
+**Sample request body with trim scheduling**
+
+```json
+{
+    "start_time": 30,
+    "end_time": 120
+}
+```
+
+:::important
+
+When scheduling a trim:
+- Both `start_time` and `end_time` are required
+- Both must be non-negative integers
+- `start_time` must be less than `end_time`
+- `end_time` cannot exceed the total duration of the live stream recording
+- The trim operation will be executed automatically after transcoding completes
+
+:::
+
+**Response with trim scheduled**
+
+```json
+{
+    "message": "Live stream stopped successfully",
+    "trim_scheduled": true
+}
+```
+
 :::important
 
 If the value of the parameter "transcode_recorded_video" is set to true, you will receive the video object in the webhook response.


### PR DESCRIPTION
#### Purpose of PR :

- Add docs for optional trim parameters in stop live stream endpoint allowing users to schedule automatic video trimming after recording completes.
- Include documentation with examples and notes about usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the "Stop a live stream" API documentation to include details about the JSON response and the new ability to schedule a trim operation on the recorded live stream by specifying `start_time` and `end_time` in the stop request.
  - Clarified requirements and behavior for trim scheduling and updated response examples accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->